### PR TITLE
Defining colors by RGB Hex

### DIFF
--- a/MPColorTools/MPColorTools.h
+++ b/MPColorTools/MPColorTools.h
@@ -27,7 +27,7 @@
 #define MP_HSBA(h,s,b,a)            (MP_HSVA(h,s,b,a))
 #define MP_GRAY(g)                  ([UIColor colorWithWhite:MP_255_SCALE(g) alpha:1])
 #define MP_GRAYA(g,a)               ([UIColor colorWithWhite:MP_255_SCALE(g) alpha:MP_RANGE_0_1(a)])
-
+#define MP_RGB_HEX(h)               ([UIColor colorWithRGB:h])
 
 @interface UIColor (MPColorTools)
 
@@ -47,6 +47,9 @@
 - (UIColor *) colorWithLightness:(CGFloat)lightness;
 // Darkens a color by a percentage
 - (UIColor *) colorWithLightness:(CGFloat)lightness alpha:(CGFloat)alpha;
+
+// color with hex
++ (UIColor*)colorWithRGB:(NSUInteger)rgb;
 
 @end
 

--- a/MPColorTools/MPColorTools.m
+++ b/MPColorTools/MPColorTools.m
@@ -202,4 +202,10 @@ static void RGB2HSL(float r, float g, float b, float* outH, float* outS, float* 
     return [UIColor colorWithHue:hue saturation:sat lightness:lightness alpha:alpha];
 }
 
+
++ (UIColor*)colorWithRGB:(NSUInteger)rgb;
+{
+    return [UIColor colorWithRed:((rgb & 0xff0000) >> 16)/255.0 green:((rgb & 0x00ff00) >> 8)/255.0 blue:(rgb & 0x0000ff)/255.0 alpha:1.0];
+}
+
 @end


### PR DESCRIPTION
I added a macro "MP_RGB_HEX" for defining colors by RGB hex. 

for example:

```
    UIColor *color = MP_RGB_HEX(0x925C40);
    [[self view] setBackgroundColor:color];
```

I'm not super happy with the name of the macro, so if someone else has a better idea for that name, it should be updated.
