### PR TITLE
Update .cocoadocs.yml

### DIFF
--- a/.cocoadocs.yml
+++ b/.cocoadocs.yml
@@ -1,7 +1,3 @@
-highlight-font: '"GT Walsheim", "gt_walsheim_regular", "Avant Garde Gothic ITCW01Dm", "Avant Garde", "Helvetica Neue", "Arial'
-body: '"Helvetica Neue", "Arial", san-serif'
-code: '"Monaco", "Menlo", "Consolas", "Courier New", monospace'
-
 highlight-color: "#ED0015"
 highlight-dark-color: "#A90010"
 darker-color: "#C6B7B2"


### PR DESCRIPTION
The CSS that is generated from the yaml file dies on the fonts, I wonder if there was a copy & paste error?

So I've removed the font section as that wasn't being used.
![screen shot 2014-07-30 at 09 58 25](https://cloud.githubusercontent.com/assets/49038/3746940/c738249e-17c7-11e4-9bfc-3e1bc21ebd2c.png)
